### PR TITLE
Update source.py

### DIFF
--- a/pdfkit/source.py
+++ b/pdfkit/source.py
@@ -8,7 +8,7 @@ class Source(object):
         self.source = url_or_file
         self.type = type_
 
-        if self.type is 'file':
+        if self.type == 'file':
             self.checkFiles()
 
     def isUrl(self):


### PR DESCRIPTION
This small fix should prevent the following error from appears in the worker logs.

/erpnext/frappe_bench/env/lib/python3.8/site-packages/pdfkit/source.py:11: SyntaxWarning: "is" with a literal. Did you mean "=="?
20:00:09 worker_short.1   |   if self.type is 'file':